### PR TITLE
Remove constant typehints from ScriptCacheService

### DIFF
--- a/src/Service/ScriptCacheService.php
+++ b/src/Service/ScriptCacheService.php
@@ -17,14 +17,8 @@ use MatthiasMullie\Minify\JS as MinifyJs;
 
 class ScriptCacheService implements ScriptCacheServiceInterface
 {
-    /**
-     * @var int
-     */
     private const CACHE_KEY_OFFSET = 8;
 
-    /**
-     * @var int
-     */
     private const CACHE_VERSION_OFFSET = 8;
 
     private ScriptCache $scriptCache;


### PR DESCRIPTION
`8` is narrower than `int`